### PR TITLE
Make MySql Connector optional

### DIFF
--- a/fake2db/fake2db.py
+++ b/fake2db/fake2db.py
@@ -6,10 +6,6 @@ import logging
 import subprocess
 import time
 
-from sqlite_handler import Fake2dbSqliteHandler
-from mysql_handler import Fake2dbMySqlHandler
-from postgresql_handler import Fake2dbPostgresqlHandler
-from mongodb_handler import Fake2dbMongodbHandler
 from helpers import fake2db_logger
 
 logger, extra_information = fake2db_logger()
@@ -64,15 +60,6 @@ def _mongodb_process_checkpoint():
         time.sleep(3)
 
 
-try:
-    fake_sqlite_handler = Fake2dbSqliteHandler()
-    fake_mysql_handler = Fake2dbMySqlHandler()
-    fake_postgresql_handler = Fake2dbPostgresqlHandler()
-    fake_mongodb_handler = Fake2dbMongodbHandler()
-except:
-    raise InstantiateDBHandlerException
-
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--rows", help="Amount of rows desired per table")
@@ -92,12 +79,22 @@ def main():
             logger.info('DB argument : %s', args.db, extra=extra_information)
 
             if args.db == 'sqlite':
+                try:
+                    from sqlite_handler import Fake2dbSqliteHandler
+                    fake_sqlite_handler = Fake2dbSqliteHandler()
+                except:
+                    raise InstantiateDBHandlerException
                 if args.name:
                     fake_sqlite_handler.fake2db_sqlite_initiator(int(args.rows), str(args.name))
                 else:
                     fake_sqlite_handler.fake2db_sqlite_initiator(int(args.rows))
                     
             elif args.db == 'mysql':
+                try:
+                    from mysql_handler import Fake2dbMySqlHandler
+                    fake_mysql_handler = Fake2dbMySqlHandler()
+                except:
+                    raise InstantiateDBHandlerException
                 _mysqld_process_checkpoint()
                 if args.name:
                     fake_mysql_handler.fake2db_mysql_initiator(int(args.rows), str(args.name))
@@ -105,6 +102,11 @@ def main():
                     fake_mysql_handler.fake2db_mysql_initiator(int(args.rows))
                     
             elif args.db == 'postgresql':
+                try:
+                    from postgresql_handler import Fake2dbPostgresqlHandler
+                    fake_postgresql_handler = Fake2dbPostgresqlHandler()
+                except:
+                    raise InstantiateDBHandlerException
                 _postgresql_process_checkpoint()
                 if args.name:
                     fake_postgresql_handler.fake2db_postgresql_initiator(int(args.rows), str(args.name))
@@ -112,6 +114,11 @@ def main():
                     fake_postgresql_handler.fake2db_postgresql_initiator(int(args.rows))
                     
             elif args.db == 'mongodb':
+                try:
+                    from mongodb_handler import Fake2dbMongodbHandler
+                    fake_mongodb_handler = Fake2dbMongodbHandler()
+                except:
+                    raise InstantiateDBHandlerException
                 _mongodb_process_checkpoint()
                 if args.name:
                     fake_mongodb_handler.fake2db_mongodb_initiator(int(args.rows), str(args.name))


### PR DESCRIPTION
Fixes #6 by rearranging the import/initialization of the DB handlers. I'm not an expert in Python, so if the code seems a bit hacky, forgive me. 
