### PR TITLE
Fix how the Postgres connector could only practically connect to localhost

### DIFF
--- a/fake2db/fake2db.py
+++ b/fake2db/fake2db.py
@@ -175,7 +175,8 @@ def main():
             host = args.host or "localhost"
             port = args.port or 5432
             fake_postgresql_handler.fake2db_postgresql_initiator(
-                host=host, port=port, number_of_rows=args.rows, name=args.name)
+                host=host, port=port, password=args.password,
+                number_of_rows=args.rows, name=args.name)
 
         elif args.db == 'mongodb':
             try:

--- a/fake2db/fake2db.py
+++ b/fake2db/fake2db.py
@@ -105,7 +105,8 @@ def _redis_process_checkpoint(host, port):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--rows", help="Amount of rows desired per table")
+    parser.add_argument("--rows", help="Amount of rows desired per table",
+                        type=int)
     parser.add_argument(
         "--db",
         help=
@@ -114,7 +115,7 @@ def main():
         "--name",
         help="OPTIONAL : Give a name to the db to be generated. ")
     parser.add_argument("--host", help="OPTIONAL : Hostname of db. ")
-    parser.add_argument("--port", help="OPTIONAL : Port of db. ")
+    parser.add_argument("--port", help="OPTIONAL : Port of db.", type=int)
     parser.add_argument("--password", help="OPTIONAL : Password for root. ")
 
     args = parser.parse_args()
@@ -137,10 +138,10 @@ def main():
             except Exception:
                 raise InstantiateDBHandlerException
             if args.name:
-                fake_sqlite_handler.fake2db_sqlite_initiator(int(args.rows),
-                                                             str(args.name))
+                fake_sqlite_handler.fake2db_sqlite_initiator(args.rows,
+                                                             args.name)
             else:
-                fake_sqlite_handler.fake2db_sqlite_initiator(int(args.rows))
+                fake_sqlite_handler.fake2db_sqlite_initiator(args.rows)
 
         elif args.db == 'mysql':
             try:
@@ -150,13 +151,13 @@ def main():
                 raise InstantiateDBHandlerException
             _mysqld_process_checkpoint()
             host = args.host or "127.0.0.1"
-            port = args.port or "3306"
+            port = args.port or 3306
             if args.name:
                 fake_mysql_handler.fake2db_mysql_initiator(
-                    host, port, args.password, int(args.rows), str(args.name))
+                    host, port, args.password, args.rows, args.name)
             else:
                 fake_mysql_handler.fake2db_mysql_initiator(
-                    host, port, args.password, int(args.rows))
+                    host, port, args.password, args.rows)
 
         elif args.db == 'postgresql':
             try:
@@ -172,13 +173,13 @@ def main():
                 raise InstantiateDBHandlerException
             _postgresql_process_checkpoint()
             host = args.host or "localhost"
-            port = args.port or "5432"
+            port = args.port or 5432
             if args.name:
                 fake_postgresql_handler.fake2db_postgresql_initiator(
-                    host, port, int(args.rows), str(args.name))
+                    host, port, args.rows, args.name)
             else:
                 fake_postgresql_handler.fake2db_postgresql_initiator(
-                    host, port, int(args.rows))
+                    host, port, args.rows)
 
         elif args.db == 'mongodb':
             try:
@@ -197,10 +198,10 @@ def main():
             port = args.port or 27017
             if args.name:
                 fake_mongodb_handler.fake2db_mongodb_initiator(
-                    host, int(port), int(args.rows), str(args.name))
+                    host, port, args.rows, args.name)
             else:
-                fake_mongodb_handler.fake2db_mongodb_initiator(host, int(port),
-                                                               int(args.rows))
+                fake_mongodb_handler.fake2db_mongodb_initiator(host, port,
+                                                               args.rows)
 
         elif args.db == 'couchdb':
             try:
@@ -217,10 +218,10 @@ def main():
             _couchdb_process_checkpoint()
 
             if args.name:
-                fake_couchdb_handler.fake2db_couchdb_initiator(int(args.rows),
-                                                               str(args.name))
+                fake_couchdb_handler.fake2db_couchdb_initiator(args.rows,
+                                                               args.name)
             else:
-                fake_couchdb_handler.fake2db_couchdb_initiator(int(args.rows))
+                fake_couchdb_handler.fake2db_couchdb_initiator(args.rows)
 
         elif args.db == 'redis':
             if args.name and (not args.name.isdigit() or int(args.name) < 0):
@@ -240,14 +241,14 @@ def main():
             except Exception:
                 raise InstantiateDBHandlerException
             host = args.host or "localhost"
-            port = args.port or "6379"
+            port = args.port or 6379
             _redis_process_checkpoint(host, port)
             if args.name:
                 fake_redis_handler.fake2db_redis_initiator(
-                    host, int(port), int(args.rows), str(args.name))
+                    host, port, args.rows, args.name)
             else:
-                fake_redis_handler.fake2db_redis_initiator(host, int(port),
-                                                           int(args.rows))
+                fake_redis_handler.fake2db_redis_initiator(host, port,
+                                                           args.rows)
 
         else:
             logger.error(

--- a/fake2db/fake2db.py
+++ b/fake2db/fake2db.py
@@ -174,7 +174,7 @@ def main():
             _postgresql_process_checkpoint()
             host = args.host or "localhost"
             port = args.port or 5432
-            fake_postgresql_handler.fake2db_postgresql_initiator(
+            fake_postgresql_handler.fake2db_initiator(
                 host=host, port=port, password=args.password,
                 number_of_rows=args.rows, name=args.name)
 

--- a/fake2db/fake2db.py
+++ b/fake2db/fake2db.py
@@ -174,12 +174,8 @@ def main():
             _postgresql_process_checkpoint()
             host = args.host or "localhost"
             port = args.port or 5432
-            if args.name:
-                fake_postgresql_handler.fake2db_postgresql_initiator(
-                    host, port, args.rows, args.name)
-            else:
-                fake_postgresql_handler.fake2db_postgresql_initiator(
-                    host, port, args.rows)
+            fake_postgresql_handler.fake2db_postgresql_initiator(
+                host=host, port=port, number_of_rows=args.rows, name=args.name)
 
         elif args.db == 'mongodb':
             try:

--- a/fake2db/fake2db.py
+++ b/fake2db/fake2db.py
@@ -154,7 +154,7 @@ def main():
             host = args.host or "localhost"
             port = args.port or 5432
             fake_postgresql_handler.fake2db_initiator(host=host, port=port,
-                user=args.username, password=args.password,
+                username=args.username, password=args.password,
                 number_of_rows=args.rows, name=args.name)
 
         elif args.db == 'mongodb':

--- a/fake2db/fake2db.py
+++ b/fake2db/fake2db.py
@@ -111,12 +111,11 @@ def main():
         "--db",
         help=
         "Db type for creation: sqlite, mysql, postgresql, mongodb, redis, couchdb, to be expanded")
-    parser.add_argument(
-        "--name",
-        help="OPTIONAL : Give a name to the db to be generated. ")
-    parser.add_argument("--host", help="OPTIONAL : Hostname of db. ")
-    parser.add_argument("--port", help="OPTIONAL : Port of db.", type=int)
-    parser.add_argument("--password", help="OPTIONAL : Password for root. ")
+    parser.add_argument("--name", help="The name to the db to be generated")
+    parser.add_argument("--host", help="Hostname of db")
+    parser.add_argument("--port", help="Port of db", type=int)
+    parser.add_argument("--username", help="Username")
+    parser.add_argument("--password", help="Password")
 
     args = parser.parse_args()
 
@@ -174,8 +173,8 @@ def main():
             _postgresql_process_checkpoint()
             host = args.host or "localhost"
             port = args.port or 5432
-            fake_postgresql_handler.fake2db_initiator(
-                host=host, port=port, password=args.password,
+            fake_postgresql_handler.fake2db_initiator(host=host, port=port,
+                user=args.username, password=args.password,
                 number_of_rows=args.rows, name=args.name)
 
         elif args.db == 'mongodb':

--- a/fake2db/fake2db.py
+++ b/fake2db/fake2db.py
@@ -1,4 +1,5 @@
 import argparse
+import getpass
 import subprocess
 import time
 
@@ -153,8 +154,9 @@ def main():
                 raise InstantiateDBHandlerException
             host = args.host or "localhost"
             port = args.port or 5432
+            username = args.username or getpass.getuser()
             fake_postgresql_handler.fake2db_initiator(host=host, port=port,
-                username=args.username, password=args.password,
+                username=username, password=args.password,
                 number_of_rows=args.rows, name=args.name)
 
         elif args.db == 'mongodb':

--- a/fake2db/fake2db.py
+++ b/fake2db/fake2db.py
@@ -15,25 +15,6 @@ class MissingDependencyException(Exception):
     '''An Exception to be thrown if the dependencies are missing'''
 
 
-def _postgresql_process_checkpoint():
-    '''this helper method checks if
-    postgresql server is available in the sys
-    if not fires up one
-    '''
-    try:
-        subprocess.check_output("pgrep postgres", shell=True)
-    except Exception:
-        logger.warning(
-            'Your postgresql server is offline, fake2db will try to launch it now!',
-            extra=extra_information)
-        # close_fds = True argument is the flag that is responsible
-        # for Popen to launch the process completely independent
-        subprocess.Popen("postgres -D /usr/local/pgsql/data",
-                         close_fds=True,
-                         shell=True)
-        time.sleep(3)
-
-
 def _mysqld_process_checkpoint():
     '''this helper method checks if
     mysql server is available in the sys
@@ -170,7 +151,6 @@ def main():
                 fake_postgresql_handler = Fake2dbPostgresqlHandler()
             except Exception:
                 raise InstantiateDBHandlerException
-            _postgresql_process_checkpoint()
             host = args.host or "localhost"
             port = args.port or 5432
             fake_postgresql_handler.fake2db_initiator(host=host, port=port,

--- a/fake2db/fake2db.py
+++ b/fake2db/fake2db.py
@@ -35,7 +35,7 @@ def _postgresql_process_checkpoint():
 
 
 def _mysqld_process_checkpoint():
-    '''this helper method checks if 
+    '''this helper method checks if
     mysql server is available in the sys
     if not fires up one
     '''
@@ -52,7 +52,7 @@ def _mysqld_process_checkpoint():
 
 
 def _mongodb_process_checkpoint():
-    '''this helper method checks if 
+    '''this helper method checks if
     mongodb server is available in the sys
     if not fires up one
     '''
@@ -69,7 +69,7 @@ def _mongodb_process_checkpoint():
 
 
 def _couchdb_process_checkpoint():
-    '''this helper method checks if 
+    '''this helper method checks if
     couchdb server is available in the sys
     if not fires up one
     '''

--- a/fake2db/postgresql_handler.py
+++ b/fake2db/postgresql_handler.py
@@ -43,12 +43,12 @@ class Fake2dbPostgresqlHandler():
         conn = None
         username = getpass.getuser()
 
-        try:
-            if name:
-                db = name
-            else:
-                db = 'postgresql_' + str_generator(self)
+        if name:
+            db = name
+        else:
+            db = 'postgresql_' + str_generator(self)
 
+        try:
             subprocess.Popen("createdb --no-password --owner " + username + " " + db, shell=True)
             time.sleep(1)
             conn = psycopg2.connect("dbname=" + db + " user=" + username + " host=" + host + " port=" + port)

--- a/fake2db/postgresql_handler.py
+++ b/fake2db/postgresql_handler.py
@@ -19,7 +19,8 @@ except ImportError:
 class Fake2dbPostgresqlHandler():
     faker = Factory.create()
 
-    def fake2db_postgresql_initiator(self, host, port, number_of_rows, name=None):
+    def fake2db_postgresql_initiator(self, number_of_rows,
+                                     host, port, password=None, name=None):
         '''Main handler for the operation
         '''
         rows = number_of_rows

--- a/fake2db/postgresql_handler.py
+++ b/fake2db/postgresql_handler.py
@@ -19,8 +19,8 @@ except ImportError:
 class Fake2dbPostgresqlHandler():
     faker = Factory.create()
 
-    def fake2db_postgresql_initiator(self, number_of_rows,
-                                     host, port, password=None, name=None):
+    def fake2db_initiator(self, number_of_rows,
+                          host, port, password=None, name=None):
         '''Main handler for the operation
         '''
         rows = number_of_rows

--- a/fake2db/postgresql_handler.py
+++ b/fake2db/postgresql_handler.py
@@ -64,20 +64,20 @@ class Fake2dbPostgresqlHandler():
 
         cursor.execute("CREATE TABLE simple_registration (id serial PRIMARY KEY, email varchar(300), password varchar(300));")
         conn.commit()
-        
+
         simple_registration_data = []
-        
+
         try:
 
             for i in range(0, number_of_rows):
                 simple_registration_data.append((self.faker.safe_email(), self.faker.md5(raw_output=False)))
-                
+
             simple_registration_payload = ("INSERT INTO simple_registration "
                                            "(email, password) "
                                            "VALUES (%s, %s)")
             cursor.executemany(simple_registration_payload, simple_registration_data)
             conn.commit()
-            
+
             logger.warning('simple_registration Commits are successful after write job!', extra=d)
 
         except Exception as e:
@@ -93,18 +93,18 @@ class Fake2dbPostgresqlHandler():
             "lastname varchar(300), name varchar(300), adress varchar(300), phone varchar(300));")
         conn.commit()
         detailed_registration_data = []
-        
+
         try:
 
             for i in range(0, number_of_rows):
-                
+
                 detailed_registration_data.append((self.faker.safe_email(), self.faker.md5(raw_output=False), self.faker.last_name(),
                                                    self.faker.first_name(), self.faker.address(), self.faker.phone_number()))
-                
+
             detailed_registration_payload = ("INSERT INTO detailed_registration "
                                              "(email, password, lastname, name, adress, phone) "
                                              "VALUES (%s, %s, %s, %s, %s, %s)")
-            
+
             cursor.executemany(detailed_registration_payload, detailed_registration_data)
             conn.commit()
             logger.warning('detailed_registration Commits are successful after write job!', extra=d)
@@ -121,21 +121,21 @@ class Fake2dbPostgresqlHandler():
         conn.commit()
 
         user_agent_data = []
-        
+
         try:
 
             for i in range(0, number_of_rows):
-                
+
                 user_agent_data.append((self.faker.ipv4(), self.faker.country_code(),
                  self.faker.user_agent()))
-                
+
             user_agent_payload = ("INSERT INTO user_agent "
                                "(ip, countrycode, useragent) "
                                "VALUES (%s, %s, %s)")
-            
+
             cursor.executemany(user_agent_payload, user_agent_data)
             conn.commit()
-            
+
             logger.warning('user_agent Commits are successful after write job!', extra=d)
         except Exception as e:
             logger.error(e, extra=d)
@@ -149,17 +149,17 @@ class Fake2dbPostgresqlHandler():
             "name varchar(300), sdate varchar(300), email varchar(300), domain varchar(300), city varchar(300));")
         conn.commit()
         company_data = []
-        
+
         try:
             for i in range(0, number_of_rows):
-                
+
                 company_data.append((self.faker.company(), self.faker.date(pattern="%d-%m-%Y"),
                                      self.faker.company_email(), self.faker.safe_email(), self.faker.city()))
-                
+
             company_payload = ("INSERT INTO company "
                                "(name, sdate, email, domain, city) "
                                "VALUES (%s, %s, %s, %s, %s)")
-            
+
             cursor.executemany(company_payload, company_data)
             conn.commit()
             logger.warning('companies Commits are successful after write job!', extra=d)
@@ -178,20 +178,20 @@ class Fake2dbPostgresqlHandler():
         conn.commit()
 
         customer_data = []
-        
+
         try:
             for i in range(0, number_of_rows):
-                
+
                 customer_data.append((self.faker.first_name(), self.faker.last_name(), self.faker.address(),
                                       self.faker.country(), self.faker.city(), self.faker.date(pattern="%d-%m-%Y"),
                                       self.faker.date(pattern="%d-%m-%Y"), self.faker.safe_email(), self.faker.phone_number(),
                                       self.faker.locale()))
-                
+
             customer_payload = ("INSERT INTO customer "
                                 "(name, lastname, address, country, city, registry_date, "
                                 "birthdate, email, phone_number, locale)"
                                 "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)")
-            
+
             cursor.executemany(customer_payload, customer_data)
             conn.commit()
             logger.warning('customer Commits are successful after write job!', extra=d)


### PR DESCRIPTION
Tis ont erpefct, but now fake2db actually works for me now.

I tried to make this a minimal change, but there were some things I could not overlook, so there's some extra changes not related to the ability to pass in username/password.

Tested locally with:
```
$ fake2db --db postgresql --rows 1337 --host elk_postgres.local --password password --user docker
2015-09-02 17:19:25,854 crccheck      Rows argument : 1337
2015-09-02 17:19:36,184 crccheck      Database created and opened succesfully: postgresql_vsgjqwju
2015-09-02 17:19:38,134 crccheck      simple_registration Commits are successful after write job!
2015-09-02 17:19:39,864 crccheck      detailed_registration Commits are successful after write job!
2015-09-02 17:19:41,488 crccheck      companies Commits are successful after write job!
2015-09-02 17:19:42,958 crccheck      user_agent Commits are successful after write job!
2015-09-02 17:19:45,376 crccheck      customer Commits are successful after write job!
```