### PR TITLE
postgresql skip create database if exsit

### DIFF
--- a/fake2db/postgresql_handler.py
+++ b/fake2db/postgresql_handler.py
@@ -43,7 +43,10 @@ class Fake2dbPostgresqlHandler(BaseHandler):
                 user=username, password=password, host=host, port=port)
             conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
             cur = conn.cursor()
-            cur.execute('CREATE DATABASE %s;' % dbname)
+            cur.execute("SELECT * FROM pg_database WHERE datname = '%s'" % dbname)
+            if cur.rowcount == 0:
+                # create database if not exist
+                cur.execute('CREATE DATABASE %s;' % dbname)
             cur.close()
             conn.close()
             # reconnect to the new database


### PR DESCRIPTION
if the database exists, we can skip create it. For example, i want to create a database only for test, so i can create one user who has all the permisson to the database , not create database permission.